### PR TITLE
Add types for SVG Props + SVG Ref

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -90,6 +90,7 @@ import { BgSquircle } from './backgrounds/BgSquircle'
 import { BgCircleMask } from './backgrounds/BgCircleMask'
 import { BgSquareMask } from './backgrounds/BgSquareMask'
 import { BgSquircleMask } from './backgrounds/BgSquircleMask'
+import { SvgProps } from 'react-native-svg'
 
 export const eyesMap = {
   normal: NormalEyes,
@@ -214,7 +215,7 @@ function selectRandomKey<T extends {}>(object: T) {
   ]
 }
 
-export interface AvatarProps {
+export interface AvatarProps extends SvgProps {
   skinTone?: keyof typeof colors.skin
   eyes?: keyof typeof eyesMap
   eyebrows?: keyof typeof eyebrowsMap
@@ -240,6 +241,7 @@ export interface AvatarProps {
   size: number
   containerStyles: StyleSheet.NamedStyles<{}>
   containerProps: ViewProps
+  svgRef?: React.Ref<React.Component<SvgProps>>
 }
 
 export const Avatar = ({
@@ -268,6 +270,7 @@ export const Avatar = ({
   size = 100,
   containerStyles = {},
   containerProps = {},
+  svgRef,
 
   ...rest
 }: AvatarProps) => {
@@ -288,6 +291,7 @@ export const Avatar = ({
   return (
     <ThemeContext.Provider value={{ colors, skin }}>
       <Base
+        svgRef={svgRef}
         eyes={Eyes}
         eyebrows={Eyebrows}
         mouth={Mouth}

--- a/src/components/Base.tsx
+++ b/src/components/Base.tsx
@@ -10,10 +10,10 @@ import { BodyProps } from './bodies/types'
 import { HatProps } from './hats/types'
 import { EyeProps } from './eyes/types'
 import { DressShirt } from './clothing/DressShirt'
-import { Svg, G, Path } from 'react-native-svg'
+import { Svg, G, Path, SvgProps } from 'react-native-svg'
 import { View, ViewProps, StyleSheet } from 'react-native'
 import { BgShapeProps, BgMaskProps } from './backgrounds/types'
-interface BaseProps {
+interface BaseProps extends SvgProps {
   eyes: React.ComponentType<EyeProps>
   eyebrows: React.ComponentType
   mouth: React.ComponentType<MouthProps>
@@ -56,6 +56,7 @@ interface BaseProps {
   size: number
   containerStyles: StyleSheet.NamedStyles<{}>
   containerProps: ViewProps
+  svgRef?: React.Ref<React.Component<SvgProps>>
 }
 
 export const Base = ({
@@ -82,7 +83,7 @@ export const Base = ({
   size = 100,
   containerStyles = {},
   containerProps = {},
-
+  svgRef,
   ...rest
 }: BaseProps) => {
   const { skin } = useTheme()
@@ -109,7 +110,7 @@ export const Base = ({
       }}
       { ...containerProps }
     >
-      <Svg viewBox="0 0 1000 990" {...rest}>
+      <Svg ref={svgRef} viewBox="0 0 1000 990" {...rest}>
         {showBackground && <BgMask id="mask" />}
         <G mask="url(#mask)">
           {showBackground && <BgShape bgColor={bgColor} />}


### PR DESCRIPTION
* I let the props (`BaseProps` and `AvatarProps`) extend from SvgProps, so the `{ ...rest }` spread made sense. (Before it only had type `{}`)
* I added a `ref` to the `<Svg>` component, this is useful if I want to convert the SVG into a PNG to store it on my users objects in the database, because the `<Avatar>` SVG Component from this library is really slow at rendering, especially in large lists (sorry). 

> For anyone wondering how to convert this to a PNG, use the `svgRef=` property to attach a ref created by `React.useRef()`, then call [`toDataURL`](https://github.com/react-native-community/react-native-svg/blob/b2f76058550a542ef500b71b41f81f410fc9d1e4/src/elements/Svg.tsx#L97-L103) on that ref instance (`ref.current` object)